### PR TITLE
Added option to monitor errors. Added errorstats to info command

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2301,6 +2301,7 @@ NULL
     } else if (!strcasecmp(c->argv[1]->ptr,"resetstat") && c->argc == 2) {
         resetServerStats();
         resetCommandTableStats();
+        resetErrorTableStats();
         addReply(c,shared.ok);
     } else if (!strcasecmp(c->argv[1]->ptr,"rewrite") && c->argc == 2) {
         if (server.configfile == NULL) {

--- a/src/module.c
+++ b/src/module.c
@@ -1250,18 +1250,6 @@ int RM_ReplyWithLongLong(RedisModuleCtx *ctx, long long ll) {
     return REDISMODULE_OK;
 }
 
-/* Reply with an error or simple string (status message). Used to implement
- * ReplyWithSimpleString() and ReplyWithError().
- * The function always returns REDISMODULE_OK. */
-int replyWithStatus(RedisModuleCtx *ctx, const char *msg, char *prefix) {
-    client *c = moduleGetReplyClient(ctx);
-    if (c == NULL) return REDISMODULE_OK;
-    addReplyProto(c,prefix,strlen(prefix));
-    addReplyProto(c,msg,strlen(msg));
-    addReplyProto(c,"\r\n",2);
-    return REDISMODULE_OK;
-}
-
 /* Reply with the error 'err'.
  *
  * Note that 'err' must contain all the error, including
@@ -1277,7 +1265,10 @@ int replyWithStatus(RedisModuleCtx *ctx, const char *msg, char *prefix) {
  * The function always returns REDISMODULE_OK.
  */
 int RM_ReplyWithError(RedisModuleCtx *ctx, const char *err) {
-    return replyWithStatus(ctx,err,"-");
+    client *c = moduleGetReplyClient(ctx);
+    if (c == NULL) return REDISMODULE_OK;
+    addReplyErrorFormat(c,"-%s",err);
+    return REDISMODULE_OK;
 }
 
 /* Reply with a simple string (+... \r\n in RESP protocol). This replies
@@ -1286,7 +1277,12 @@ int RM_ReplyWithError(RedisModuleCtx *ctx, const char *err) {
  *
  * The function always returns REDISMODULE_OK. */
 int RM_ReplyWithSimpleString(RedisModuleCtx *ctx, const char *msg) {
-    return replyWithStatus(ctx,msg,"+");
+    client *c = moduleGetReplyClient(ctx);
+    if (c == NULL) return REDISMODULE_OK;
+    addReplyProto(c,"+",1);
+    addReplyProto(c,msg,strlen(msg));
+    addReplyProto(c,"\r\n",2);
+    return REDISMODULE_OK;
 }
 
 /* Reply with an array type of 'len' elements. However 'len' other calls

--- a/src/server.c
+++ b/src/server.c
@@ -4533,11 +4533,14 @@ void monitorCommand(client *c) {
     c->flags |= (CLIENT_SLAVE|CLIENT_MONITOR);
 
     /* option to monitor commands that resulted in ERR */
-    if(c->argc >= 2 && !strcasecmp(errors,"errors")){
-        c->flags |= CLIENT_MONITOR_ERRORS;
-    }else{
-        addReplyErrorFormat(c,"only ERRORS allowed as optional argument for '%s' command. Ignoring extra argument.",
-                      c->cmd->name);
+    if(c->argc >= 2){
+        if(!strcasecmp(errors,"errors") ){
+            c->flags |= CLIENT_MONITOR_ERRORS;
+        }
+        else{
+            addReplyErrorFormat(c,"only ERRORS allowed as optional argument for '%s' command. Ignoring extra argument.",
+                                c->cmd->name);
+        }
     }
     listAddNodeTail(server.monitors,c);
     addReply(c,shared.ok);


### PR DESCRIPTION
this PR pushes forward the observability on error monitoring and statistics within redis-server. 
Right now, clients that are sending wrong commands to redis, are not possible to detect either via `INFO` statistics or via `MONITOR`debugging command.  We can completly top-up redis-server while only issuing commands that result in error without it being visible. 
try the following ( will top up one redis-server instance ):
```
redis-benchmark  -n 10000000000 -q BADCOMMAND
```
```
$ redis-cli info cpu
# CPU
used_cpu_sys:146.688002
used_cpu_user:119.395936
used_cpu_sys_children:0.002179
used_cpu_user_children:0.000631
```

[MONITOR](https://redis.io/commands/monitor) only streams back every command processed by the Redis server if the command was successfull. try the following:

# current unstable version

redis-cli client 1 ( sending commands ):
```
$ redis-cli 
127.0.0.1:6379> set foo bar
OK
127.0.0.1:6379> set foo
(error) ERR wrong number of arguments for 'set' command
127.0.0.1:6379>
```

redis-cli client 2 ( monitoring all commands processed ). right now only observes sucessfull commands. 
```
$ redis-cli
127.0.0.1:6379> monitor
OK
1575463372.959088 [0 127.0.0.1:51257] "set" "foo" "bar"
```

# version option to monitor errors and added errorstats to info command

redis-cli client 1 ( sending commands ):
```
$ redis-cli 
127.0.0.1:6379> set foo bar
OK
127.0.0.1:6379> set foo
(error) ERR wrong number of arguments for 'set' command
127.0.0.1:6379>
```

redis-cli client 2 ( monitoring all commands processed (errors included) ).
```
$ redis-cli
127.0.0.1:6379> monitor errors
OK
1575463569.596154 [0 127.0.0.1:51275] "COMMAND"
1575463577.235855 [0 127.0.0.1:51275] "set" "foo" "bar"
1575463579.460917 [0 127.0.0.1:51275] [(error) ERR wrong number of arguments for 'set' command] after processing the command set
```

## observe all errors occurring on the server. 
Right now all errors are aggregate as [simple error](https://gist.github.com/antirez/2bc68a9e9e45395e297d288453d5d54c#simple-types)
```
$ redis-cli 
127.0.0.1:6379> info errorstats
# Errorstats
errorstat_all_simple_error:calls=1003
```

In the future, if you guys find this a good idea, we should assess all errors and properly document and split their statistics. 



