### PR TITLE
Queuestats

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1788,6 +1788,7 @@ void readQueryFromClient(connection *conn) {
     client *c = connGetPrivateData(conn);
     int nread, readlen;
     size_t qblen;
+    c->lasteventtime = server.ustime;
 
     /* Check if we want to read from the client later when exiting from
      * the event loop. This is the case if threaded I/O is enabled. */

--- a/src/server.h
+++ b/src/server.h
@@ -779,6 +779,7 @@ typedef struct client {
                                buffer or object being sent. */
     time_t ctime;           /* Client creation time. */
     time_t lastinteraction; /* Time of the last interaction, used for timeout */
+    ustime_t lasteventtime; /* Time of the last event start, used for queue statistics */
     time_t obuf_soft_limit_reached_time;
     uint64_t flags;         /* Client flags: CLIENT_* macros. */
     int authenticated;      /* Needed when the default user requires auth. */
@@ -1088,6 +1089,7 @@ struct redisServer {
     /* Fields used only for stats */
     time_t stat_starttime;          /* Server start time */
     long long stat_numcommands;     /* Number of processed commands */
+    long long stat_queueing_delay_total_us; /* Commands overall queueing delay us */
     long long stat_numconnections;  /* Number of connections received */
     long long stat_expiredkeys;     /* Number of expired keys */
     double stat_expired_stale_perc; /* Percentage of keys probably expired */


### PR DESCRIPTION
This PR adds methodologies for evaluating congestion among redis, enabling us to measure the trade-off between active connections, throughput and queue delay. How? Right now we only track time within the command processing himself. We've added an extra metric to the client structure to track time right after we receive an read event.

As an example, for a simple local benchmark on lrange, with values of 10K, and 512 clients we see that ( this is an extreme example ):
```
$ redis-cli info commandstats
# Commandstats
queue_delay_stat_overall:calls=266290,usec=112386753,usec_per_call=422.05
cmdstat_config:calls=1,usec=13,usec_per_call=13.00
cmdstat_info:calls=2,usec=65,usec_per_call=32.50
cmdstat_lrange:calls=266287,usec=33544366,usec_per_call=125.97
```

for a simple test suite that does not contain any long command the queue time is a lot different:
```
$ redis-cli info commandstats
# Commandstats
queue_delay_stat_overall:calls=2364116,usec=30774856,usec_per_call=13.02
cmdstat_config:calls=1,usec=7,usec_per_call=7.00
cmdstat_set:calls=800000,usec=437245,usec_per_call=0.55
cmdstat_get:calls=764097,usec=965705,usec_per_call=1.26
cmdstat_info:calls=18,usec=603,usec_per_call=33.50
cmdstat_hset:calls=800000,usec=593074,usec_per_call=0.74
```
