### PR TITLE
networking: addReplyBulkCBuffer single-write fast path

### DIFF
--- a/src/networking.c
+++ b/src/networking.c
@@ -1331,9 +1331,52 @@ void addReplyBulk(client *c, robj *obj) {
     addReplyBulkWithFlag(c, obj, 1);
 }
 
-/* Add a C buffer as bulk reply */
+/* Add a C buffer as bulk reply.
+ *
+ * Fast path emits "$N\r\n<payload>\r\n" with a single contiguous write into
+ * the static client buffer when the common-case flags allow it, avoiding the
+ * 3 separate _addReplyToBufferOrList() calls (one per piece) and the per-call
+ * branch chain each of those would re-run. Falls back to the original 3-call
+ * path for the cases the fast path can't handle (reply-list non-empty,
+ * encoded RESP3 buffer, replica/push/close-after-reply, or buffer overflow). */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     if (_prepareClientToWrite(c) != C_OK) return;
+
+    if (likely(listLength(c->reply) == 0) &&
+        likely(!c->buf_encoded) &&
+        likely(!(c->flags & (CLIENT_CLOSE_AFTER_REPLY | CLIENT_PUSHING))) &&
+        likely(!clientTypeIsSlave(c)))
+    {
+        const char *hdr;
+        size_t hdr_len;
+        char hdr_buf[24]; /* Enough for "$<INT64_MAX>\r\n". */
+        if (likely(len < OBJ_SHARED_BULKHDR_LEN)) {
+            hdr = shared.bulkhdr[len]->ptr;
+            hdr_len = OBJ_SHARED_HDR_STRLEN(len);
+        } else {
+            hdr_buf[0] = '$';
+            int n = ll2string(hdr_buf + 1, sizeof(hdr_buf) - 3, (long long)len);
+            hdr_buf[n + 1] = '\r';
+            hdr_buf[n + 2] = '\n';
+            hdr = hdr_buf;
+            hdr_len = (size_t)(n + 3);
+        }
+        const size_t total = hdr_len + len + 2;
+
+        if (likely(c->buf_usable_size - c->bufpos >= total)) {
+            char *dst = c->buf + c->bufpos;
+            memcpy(dst, hdr, hdr_len);
+            memcpy(dst + hdr_len, p, len);
+            dst[hdr_len + len    ] = '\r';
+            dst[hdr_len + len + 1] = '\n';
+            c->bufpos += total;
+            c->net_output_bytes_curr_cmd += total;
+            if (c->buf_peak < (size_t)c->bufpos) c->buf_peak = (size_t)c->bufpos;
+            reqresSaveClientReplyOffset(c);
+            return;
+        }
+    }
+
     _addReplyLongLongBulk(c, len);
     _addReplyToBufferOrList(c, p, len);
     _addReplyToBufferOrList(c, "\r\n", 2);

--- a/src/networking.c
+++ b/src/networking.c
@@ -1338,7 +1338,11 @@ void addReplyBulk(client *c, robj *obj) {
  * 3 separate _addReplyToBufferOrList() calls (one per piece) and the per-call
  * branch chain each of those would re-run. Falls back to the original 3-call
  * path for the cases the fast path can't handle (reply-list non-empty,
- * encoded RESP3 buffer, replica/push/close-after-reply, or buffer overflow). */
+ * encoded RESP3 buffer, replica/push/close-after-reply, or buffer overflow).
+ *
+ * Note: callers that already produce a contiguous "$N\r\n<payload>\r\n"
+ * sequence (e.g. addReplyBulkSds with sufficient slack) could plug in here
+ * directly; explored as a follow-up. */
 void addReplyBulkCBuffer(client *c, const void *p, size_t len) {
     if (_prepareClientToWrite(c) != C_OK) return;
 


### PR DESCRIPTION
## Summary

`addReplyBulkCBuffer` emits each bulk reply via three separate
`_addReplyToBufferOrList` calls — one for the `$N\r\n` header, one for the
payload, one for the trailing `\r\n`. Each call re-runs the same per-call
overhead chain: CLIENT flag checks, replica panic check, push-deferral
check, `net_output_bytes_curr_cmd` update, `reqresSaveClientReplyOffset`,
list-length / encoded-buffer check, and the actual `memcpy`. For the
common case (small payload, fits in the static buffer), this is wasted
work — the three pieces could be written into the buffer in one
contiguous chain.

This PR adds a fast path inside `addReplyBulkCBuffer` that emits the
whole `"$N\r\n<payload>\r\n"` sequence in one inlined memcpy chain when
the common-case flags allow it. Falls back to the original three-call
path for the cases the fast path can't handle (reply-list non-empty,
encoded RESP3 buffer, replica/push/close-after-reply, or buffer
overflow).

## Profiling motivation

CPU profile against `unstable` (24h window, x86 m7i bare-metal,
parca-agent on-CPU samples). The addReply chain dominates every
bulk-reply workload:

| Workload                    | `_addReplyPayloadToBuffer` flat | `_addReplyToBufferOrList` flat | `addReplyBulkCBuffer` flat | combined |
|---|---:|---:|---:|---:|
| LRANGE 100 ints pipeline-10 | 8.56 % | 5.27 % | 2.47 % | **~16 %**  |
| HGETALL 1K fields           | 4.25 % | 4.48 % | 2.06 % | **~11 %**  |
| SMEMBERS 1K elements        | 6.07 % | 3.35 % | 1.38 % | **~11 %**  |

`addReplyBulkCBuffer` reaches **27.1 % cumulative** on LRANGE.
Disassembly (`objdump -d`) confirms LTO did not inline the three
`_addReplyToBufferOrList` calls into the bulk function — three explicit
branches into the `_addReplyToBufferOrList.part.0` outline are emitted.

## Patch

A single function changes (`src/networking.c::addReplyBulkCBuffer`,
44 LOC added). The fast-path gate checks:

- `listLength(c->reply) == 0`     (so the whole reply lands in `c->buf`)
- `!c->buf_encoded`               (RESP3 attribute encoding stays on slow path)
- not `CLIENT_CLOSE_AFTER_REPLY` and not `CLIENT_PUSHING`
- not a replica client
- header + payload + 2 fits in `c->buf_usable_size - c->bufpos`

When all gates pass, the fast path:
1. Looks up the bulk header from `shared.bulkhdr[len]` (`len < 32`) or
   formats it on the stack (`ll2string`).
2. `memcpy(dst, hdr, hdr_len); memcpy(dst + hdr_len, p, len); dst[...] = '\r'; dst[...] = '\n';`
3. Updates `c->bufpos`, `c->net_output_bytes_curr_cmd`, `c->buf_peak`,
   then calls `reqresSaveClientReplyOffset(c)` once.
4. Returns.

The slow path is unchanged byte-for-byte and still handles every case
the fast path can't. Replica writes still hit the existing
`logInvalidUseAndFreeClientAsync` panic via the slow path.

## Benchmarks

Two AWS bare-metal runners: x86 `m7i.metal-24xl-2` (Intel Sapphire
Rapids) and ARM `m8g.metal-24xl-2` (Neoverse-V2). Two independent PR
builds (commit `d29e650b0` and a doc-only follow-up `ae302f1a1` at the
same code) were each compared against `unstable @ fab099cdcf`. The two
PR builds agree within < 1 % on every cell — wins are reproducible.

| Test | x86 m7i-2 (PR_old → PR_new vs base) | x86 Δ | arm m8g-2 (PR_old → PR_new vs base) | arm Δ |
|---|---|---:|---|---:|
| `1key-list-100-elements-int-7bit-uint-lrange-all-elements-pipeline-10` | 398596 → 399611 vs 293416 | **+36.02 %** | 124709 → 124789 vs 124550 | +0.16 % |
| `1key-hash-1K-fields-hgetall`                                          | 22382 → 22335 vs 18309 | **+22.12 %** | 6684 → 6685 vs 6678 | +0.10 % |
| `1key-hash-1K-fields-hgetall-pipeline-10`                              | 17966 → 17881 vs 18470 | -2.96 % | 6588 → 6597 vs 6616 | -0.35 % |
| `1key-set-1K-elements-smembers`                                        | 49191 → 48712 vs 30586 | **+60.04 %** | 12589 → 12559 vs 12533 | +0.32 % |

Magnitudes match theory. Per element-add the patch saves roughly two
function calls (~3 ns each) plus the redundant flag/list-length checks
(~2 ns) ≈ ~8 ns of overhead. For workloads with many small bulks
(SMEMBERS 1K × 10B, LRANGE 100 × 1B), per-element overhead dominates
total time — explaining the +36–60 % gains. ARM doesn't see the wins
because its core's branch prediction and ld-st pipelining hide the
per-call overhead anyway.

The one negative cell — HGETALL pipeline-10 at -2.96 % on Intel — is
within typical fleet noise. Plausible cause: pipelining 10 HGETALLs
fills the static buffer fast, so most calls fall back to the slow path;
the fast-path gate evaluation is then wasted work. This is right at the
±3 % regression bar; happy to add an early-skip if reviewers prefer.

## Backward compatibility / risk

- **RESP framing**: identical wire bytes verified via raw netcat against
  a locally-built server (`*N`, `$len`, payload, `\r\n` in correct positions).
- **Unit tests**: `unit/protocol`, `unit/type/{list,hash,set,zset,stream}`,
  `unit/pubsub`, `unit/scripting` all pass.
- **Replica-write panic**: preserved via slow-path fallback.
- **CLIENT_PUSHING / executing_client push-deferral**: preserved via
  slow-path fallback.
- **CLIENT_CLOSE_AFTER_REPLY**: preserved via slow-path early-return.
- **RESP3 `c->buf_encoded`**: preserved via slow-path
  `tryAddPayload` invariants.
- **Buffer overflow**: fast-path gate defers to slow path which handles
  the split-write to `c->reply` list.
- **`net_output_bytes_curr_cmd`**: fast path adds `total` once
  (`hdr_len + len + 2`); equivalent to the slow path's three separate
  increments.
- **`buf_peak`**: updated after the writes; same end state.
- **`reqresSaveClientReplyOffset` (`LOG_REQ_RES`)**: called once at end
  of fast path; the `c->reqres.offset.saved` idempotency guard makes
  this equivalent to the slow path's three calls.

## Reproduction

```
redis-benchmarks-spec-cli \
  --gh_org filipecosta90 --gh_repo redis --use-branch \
  --branch filipecosta90/addreply-bulk-batched-fastpath \
  --build_command "sh -c 'make -j'" \
  --tests-regexp '.*(1key-list-100-elements-int-7bit-uint-lrange-all|1key-hash-1K-fields-hgetall|1key-set-1K-elements-smembers).*' \
  --target-platform x86-aws-m7i.metal-24xl-2 --arch amd64
```

## Test plan

- [x] `make test` (8 relevant unit suites pass)
- [x] Raw-netcat HGETALL framing check
- [x] Fleet runs on both archs, two independent PR builds — wins
      reproducible
- [ ] Reviewer-driven: any additional bulk-reply shapes you'd like
      benchmarked

## Commits

The branch has two commits — `d29e650b0` (the 44-LOC fast path) and
`ae302f1a1` (a doc-only follow-up I pushed to bump the hash for
benchmark validation; happy to squash/amend if preferred).
